### PR TITLE
Fix ouput display in child process

### DIFF
--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -212,8 +212,9 @@ void roosh_loop(std::istream &in)
             push_command(line);
 
             // execute all the commands specified in the line
+            tcsetattr(0, TCSANOW, &old); // restore original terminal settings
             bool status = roosh_launch(line);
-
+            tcsetattr(0, TCSANOW, &current); // set the new settings
             history.insert(history.begin(), keyboard.buffer);
 
             historyCount++;


### PR DESCRIPTION
This PR restore the original terminal settings when another child process was taking input so that the input becomes visible 